### PR TITLE
Improvements to `Movie`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+### 7/16/2021 15:39
+
+#### Improvements to `Movie`
+
+* This class has been largely overhauled to adopt a similar construction to `TV`.
+
+* Release year parsing now utilizes regular expressions.
+	* It is hardcoded to search for numbers in between `1800` and `2[century][decade]9`, where the middle two are
+	  bounded by the current year.
+		* This may pose a problem with names that contain a number such as this; user discretion is advised.
+
+* Logging has been added to various methods.
+
+#### `TV` Abstraction
+
+* `MetadataOps` now houses `removeUnwantedSpaces()` and `removeBrackets` (originally found in `TV`).
+	* `removeBrackets` can now remove leading or trailing brackets that do not have a counterpart, replacing them with
+	  an empty space character.
+
+#### Known bugs
+
+* After answering the prompt to add more files to the queue, the program registers an "Invalid directory" error before
+  allowing user input.
+  ``` java
+  Input the destination directory: 	// First request, unable to respond
+  Input the destination directory:	// Second request, able to respond
+  Invalid directory.			// This one appears as a response to the first request for a directory.
+  /* USER ENTRY HERE */			// This would respond to the second request
+  ```
+
+#### Priorities
+
+1. Semi-automated testing with JUnit.
+2. Allow for more granular user input and refine user experience.
+	1. Modifying created media files post-extraction.
+	2. Allow for users to dictate what goes together in the same folders.
+
+3. Explore possibilities of different interfaces, such as:
+	- semi-automated, headless operation
+	- GUI
+	- command line arguments
+	- website
+
+4. Reimplement "history" output that summarizes all operations into a text file.
+
+> ***Future:*** Add support for moving subtitles that have the same name.
+> 
+> ***Future:*** Consider using other algorithms to speed up execution.
+> > Using `String.contains()` and other string methods is not very optimal, but it is done repeatedly in the program. A possible improvement would be the [Boyer–Moore string-search algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm#Implementations).
+>
+> ***Future:*** Implement *ffmpeg*'s *ffprobe* functionality to qet more reliable and abundant metadata information from
+> files.
+> > This library may be of use here: [FFmpeg Java](https://github.com/bramp/ffmpeg-cli-wrapper)
+>
+> ***Future:*** Implement online API media verification for additional metadata or corrections.
+>
+> ***Future:*** Make the program semi-automated with the usage of command line arguments to allow for scheduled or
+> programmatic organization.
+
 ### 7/14/2021 12:05
 
 #### Implemented copy-paste-delete operation

--- a/src/main/java/general/Main.java
+++ b/src/main/java/general/Main.java
@@ -1,30 +1,23 @@
 package general;
 
-import media.MediaQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import yjohnson.ConsoleEvent;
 
-import java.io.File;
-import java.util.Date;
+
 
 public class Main {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(Main.class);
 	public static String APP_NAME;
 	public static String VERSION;
-	public static File PROGRAM_DIR;
-	public static Date CURR_DATE;
-	private static MediaQueue queue;
 
 	static {
 		APP_NAME = "Relocatinator";
 		VERSION = "0.2";
-		PROGRAM_DIR = new File(System.getProperty("user.dir"));
-		CURR_DATE = new Date();
 	}
 
 	public static void main(String[] args) {
+		logger.info("{} V{}: Starting CLI application.", APP_NAME, VERSION);
 		CLI.run();
 
 	}

--- a/src/main/java/media/Media.java
+++ b/src/main/java/media/Media.java
@@ -3,6 +3,8 @@ package media;
 import java.io.File;
 import java.nio.file.Path;
 
+import static media.MetadataOps.unwantedSpaces;
+
 abstract public class Media {
 	protected File file;
 	protected String customName, resolution = "Unknown";
@@ -56,7 +58,7 @@ abstract public class Media {
 	}
 
 	/**
-	 * Returns the deduced name of the work that this media object represents. For TV shhows, this would be the series' name, whereas for movies, it
+	 * Returns the deduced name of the work that this media object represents. For TV shows, this would be the series' name, whereas for movies, it
 	 * would be the movie's title.
 	 *
 	 * @return the deduced title of this media object.

--- a/src/main/java/media/MetadataOps.java
+++ b/src/main/java/media/MetadataOps.java
@@ -20,6 +20,7 @@ public class MetadataOps {
 
 	static {
 		resRegex = new String[]{
+				"(3996\\s?x\\s?)?(?<" + RESOLUTION + ">2160?)",
 				"(1920\\s?x\\s?)?(?<" + RESOLUTION + ">1080p?)",
 				"(1280\\s?x\\s?)?(?<" + RESOLUTION + ">720p?)",
 				"(854\\s?x\\s?)?(?<" + RESOLUTION + ">480p?)"
@@ -53,5 +54,57 @@ public class MetadataOps {
 
 		logger.warn("Resolution was NOT identified for \"{}\"; returning \"{}\".", fn, RES_UNKNOWN);
 		return RES_UNKNOWN;
+	}
+
+	public static String removeUnwantedSpaces(String s) {
+		for (String e : unwantedSpaces) {
+			if (s.contains(e)) s = s.replace(e, " ").trim();
+		}
+		return s;
+	}
+
+	static String removeBrackets(String seriesName) {
+		if (seriesName == null) return "";
+		logger.debug("Removing brackets from string \"{}\".", seriesName);
+		for (int bracketArrIdx = 0; bracketArrIdx < unwantedBrackets.length - 1; bracketArrIdx += 2) {
+			String leadingBracket = unwantedBrackets[bracketArrIdx];
+			String trailingBracket = unwantedBrackets[bracketArrIdx + 1];
+			logger.trace("Searching for instances of '{}' within \"{}\".", leadingBracket, seriesName);
+			while (seriesName.contains(String.valueOf(leadingBracket))) {
+				int idx1 = -1, idx2 = -1;
+				char[] snCharArr = seriesName.toCharArray();
+				for (int snIdx = 0; (snIdx < snCharArr.length) && !(idx1 < idx2); snIdx++) {                // O(n)
+					char c = snCharArr[snIdx];
+					if (c == leadingBracket.charAt(0)) {
+						logger.trace("Found '{}' within \"{}\" at index {}.", leadingBracket, seriesName, snIdx);
+						idx1 = snIdx;
+					} else {
+						if (c == trailingBracket.charAt(0)) {
+							logger.trace("Found '{}' within \"{}\" at index {}.", trailingBracket, seriesName, snIdx);
+							idx2 = snIdx;
+						}
+					}
+				}
+				if (idx1 < idx2) {
+					logger.debug("Removing substring \"{}\" from series name \"{}\".", seriesName.substring(idx1, idx2 + 1), seriesName);
+					seriesName = seriesName.replace(seriesName.substring(idx1, idx2 + 1), "");
+				} else if (idx1 > -1 && idx2 == -1){
+					logger.debug(
+							"Leading bracket '{}' does not have a counterpart in string \"{}\", replacing it with ' '.",
+							leadingBracket,
+							seriesName
+					);
+					seriesName = seriesName.replace(leadingBracket, " ");
+				} else {
+					logger.debug(
+							"Trailing bracket '{}' does not have a counterpart in string \"{}\", replacing it with ' '.",
+							trailingBracket,
+							seriesName
+					);
+					seriesName = seriesName.replace(trailingBracket, " ");
+				}
+			}
+		}
+		return seriesName;
 	}
 }


### PR DESCRIPTION
7/16/2021 15:39
Improvements to Movie
This class has been largely overhauled to adopt a similar construction to TV.

Release year parsing now utilizes regular expressions.

It is hardcoded to search for numbers in between 1800 and 2[century][decade]9, where the middle two are bounded by the current year.
This may pose a problem with names that contain a number such as this; user discretion is advised.
Logging has been added to various methods.

TV Abstraction
MetadataOps now houses removeUnwantedSpaces() and removeBrackets (originally found in TV).
removeBrackets can now remove leading or trailing brackets that do not have a counterpart, replacing them with an empty space character.