### PR TITLE
FileOperation and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+### 7/31/2021 20:35
+
+#### Improvements to `CLI` and `Operations`
+
+* `enum FileOperation` has been moved to its own file.
+* `Operations` now has a more OOP implementation that has the calling function "create" an operation and also the option
+  of postponing the "execution". The key difference is that now, the caller must only worry about the `FileOperation`
+  enumeration adn the constructor, not the specific function names.
+	* This has room for improvement; namely, skipping `Operations` entirely and just invoking its methods from
+	  the `FileOperation` enum itself.
+
+* `MediaQueue` now has an improved `toString()` implementation that provides better detail regarding the contents of the
+  queue.
+
+#### Known bugs
+
+* After answering the prompt to add more files to the queue, the program registers an "Invalid directory" error before
+  allowing user input.
+  ``` java
+  Input the destination directory: 	// First request, unable to respond
+  Input the destination directory:	// Second request, able to respond
+  Invalid directory.			// This one appears as a response to the first request for a directory.
+  /* USER ENTRY HERE */			// This would respond to the second request
+  ```
+
+#### Priorities
+
+1. Semi-automated testing with JUnit.
+2. Allow for more granular user input and refine user experience.
+	1. Modifying created media files post-extraction.
+	2. Allow for users to dictate what goes together in the same folders.
+
+3. Explore possibilities of different interfaces, such as:
+	- semi-automated, headless operation
+	- GUI
+	- command line arguments
+	- website
+
+4. Reimplement "history" output that summarizes all operations into a text file.
+
+> ***Future:*** Add support for moving subtitles that have the same name.
+>
+> ***Future:*** Consider using other algorithms to speed up execution.
+> > Using `String.contains()` and other string methods is not very optimal, but it is done repeatedly in the program. A possible improvement would be the [Boyer–Moore string-search algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm#Implementations).
+>
+> ***Future:*** Implement *ffmpeg*'s *ffprobe* functionality to qet more reliable and abundant metadata information from
+> files.
+> > This library may be of use here: [FFmpeg Java](https://github.com/bramp/ffmpeg-cli-wrapper)
+>
+> ***Future:*** Implement online API media verification for additional metadata or corrections.
+>
+> ***Future:*** Make the program semi-automated with the usage of command line arguments to allow for scheduled or
+> programmatic organization.
+> 
 ### 7/16/2021 15:39
 
 #### Improvements to `Movie`
@@ -46,7 +100,7 @@
 4. Reimplement "history" output that summarizes all operations into a text file.
 
 > ***Future:*** Add support for moving subtitles that have the same name.
-> 
+>
 > ***Future:*** Consider using other algorithms to speed up execution.
 > > Using `String.contains()` and other string methods is not very optimal, but it is done repeatedly in the program. A possible improvement would be the [Boyer–Moore string-search algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm#Implementations).
 >

--- a/src/main/java/general/CLI.java
+++ b/src/main/java/general/CLI.java
@@ -4,6 +4,7 @@ import media.MediaQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import yjohnson.ConsoleEvent;
+import yjohnson.FileOperation;
 import yjohnson.Operations;
 
 import java.io.File;
@@ -20,15 +21,14 @@ public class CLI {
 		CLI.printHeader();
 		queue = CLI.createMediaQueueCLI(queue);
 
-		ConsoleEvent.print("Overview of Operations: " + queue.stringOfContents());
+		ConsoleEvent.print("Overview of Operations: " + queue.toString());
 
 		if (ConsoleEvent.askUserForBoolean("Confirm?")) {
-			Operations.FileOperation fo = Operations.FileOperation.values()[ConsoleEvent.askUserForOption(
+			FileOperation fo = FileOperation.values()[ConsoleEvent.askUserForOption(
 					"Choose an operation",
-					Arrays.asList(Operations.FileOperation.toStringArray())
+					Arrays.asList(FileOperation.toStringArray())
 			) - 1];
 
-			Operations op = new Operations();
 
 			ConsoleEvent.print("Starting media queue move operation.");
 			File target;
@@ -38,18 +38,8 @@ public class CLI {
 				validDest = target.isAbsolute();
 				if (!validDest) ConsoleEvent.print("Invalid directory.", ConsoleEvent.logStatus.ERROR);
 			} while (!validDest);
-
-			switch (fo) {
-				case MOVE_FILE_ATOMICALLY:
-					op.ioStandardMoveRunner(queue, target);
-					ConsoleEvent.print("Move finalized!");
-					break;
-				case COPY_FILE_AND_DELETE_SRC:
-					op.ioNonAtomicMoveRunner(queue, target);
-					break;
-				default:
-					logger.error("Operation {} not implemented!", fo);
-			}
+			Operations op = new Operations(fo, queue, target);
+			op.executeFileOperation();
 
 		}
 

--- a/src/main/java/media/MediaQueue.java
+++ b/src/main/java/media/MediaQueue.java
@@ -69,17 +69,53 @@ public class MediaQueue implements Iterable<MediaQueue.MediaList> {
 		return sb.toString();
 	}
 
+	@Override
+	public Iterator<MediaList> iterator() {
+		return queue.iterator();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("Media Queue (sublists = ")
+		       .append(this.queue.size())
+		       .append(", items = ")
+		       .append(this.size())
+		       .append("):")
+		       .append("\n");
+
+		for (int listIdx = 0; listIdx < queue.size(); listIdx++) {
+			MediaList mediaList = queue.get(listIdx);
+			builder.append(listIdx + 1)
+			       .append(". ")
+			       .append(mediaList.toString())
+			       .append(" (items = ")
+			       .append(mediaList.size())
+			       .append(")")
+			       .append("\n");
+
+			for (int itemIdx = 0; itemIdx < mediaList.size(); itemIdx++) {
+				var item = mediaList.getMediaList().get(itemIdx);
+				builder.append(" ")
+				       .append(listIdx + 1)
+				       .append('.')
+				       .append(itemIdx + 1)
+				       .append(". ")
+				       .append(item.getFile().getName())
+				       .append(" -> ")
+				       .append(item.getCustomFilename())
+				       .append("\n");
+			}
+		}
+		return builder.toString();
+	}
+
 	public int size() {
 		int size = 0;
 		for (MediaList l : queue) {
 			size += l.size();
 		}
 		return size;
-	}
-
-	@Override
-	public Iterator<MediaList> iterator() {
-		return queue.iterator();
 	}
 
 	public static class MediaList implements Iterable<Media> {
@@ -152,6 +188,10 @@ public class MediaQueue implements Iterable<MediaQueue.MediaList> {
 						m.getCustomFilename()
 				);
 			}
+		}
+
+		private LinkedList<Media> getMediaList() {
+			return mediaList;
 		}
 
 		@Override

--- a/src/main/java/yjohnson/FileOperation.java
+++ b/src/main/java/yjohnson/FileOperation.java
@@ -1,0 +1,16 @@
+package yjohnson;
+
+public enum FileOperation {
+
+	MOVE_FILE_ATOMICALLY, COPY_FILE_AND_DELETE_SRC;
+
+	public static String[] toStringArray() {
+		String[] strings = new String[values().length];
+		FileOperation[] values = values();
+		for (int i = 0; i < values.length; i++) {
+			FileOperation fop = values[i];
+			strings[i] = fop.toString().replace('_', ' ');
+		}
+		return strings;
+	}
+}


### PR DESCRIPTION
7/31/2021 20:35
Improvements to CLI and Operations
enum FileOperation has been moved to its own file.

Operations now has a more OOP implementation that has the calling function "create" an operation and also the option of postponing the "execution". The key difference is that now, the caller must only worry about the FileOperation enumeration adn the constructor, not the specific function names.

This has room for improvement; namely, skipping Operations entirely and just invoking its methods from the FileOperation enum itself.
MediaQueue now has an improved toString() implementation that provides better detail regarding the contents of the queue.